### PR TITLE
Update check_jsonschema.py

### DIFF
--- a/check_jsonschema.py
+++ b/check_jsonschema.py
@@ -123,7 +123,7 @@ def main():
             if filename in failures:
                 err = failures[filename]
                 path = (
-                    ".".join(x if "." not in x else f'"{x}"' for x in err.path)
+                    ".".join(str(x) if "." not in str(x) else f'"{str(x)}"' for x in err.path)
                     or "<root>"
                 )
                 print(f'  \033[0;33m{filename}::{path}: \033[0m{err.message}')


### PR DESCRIPTION
Stringifying path resolving logic for Schema Validation Error output.

This fixes a unexpected thrown exception for parts of the path that were integers (element number in json array per example)